### PR TITLE
Version 1.4 fixes empty string data return exception 

### DIFF
--- a/SQLJSONReader.nuspec
+++ b/SQLJSONReader.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>SQLJSONReader</id>
+    <version>1.0.1</version>
+    <title>Reader of JSON from SQL Server</title>
+    <authors>William Wegerson</authors>
+    <owners></owners>
+	<iconUrl>https://github.com/CheetahChrome/SQLJSONReader/blob/master/SQLJSONReader/images/Buddy%20bleu.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+	<license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://github.com/CheetahChrome/SQLJSONReader</projectUrl>
+    <description>SQL JSON Reader to handle multiple JSON lines from SQL Server database call. 
+
+An extension to the SQLCommand as `cmd.ExecuteJsonReaderAsync()` which reader returns a string of JSON data.</description>
+    <summary>Allows for reading of JSON which has been returned from a call to SQL Server. Avoids the 2033 character issue as found with `ExecuteXMLReader`.</summary>
+    <copyright>2019</copyright>
+    <language>en-US</language>
+    <tags>JSON "Sql Server" reader "Stored Proc" Procedure</tags>
+  </metadata>
+</package>

--- a/SQLJSONReader/SQLExtensions.cs
+++ b/SQLJSONReader/SQLExtensions.cs
@@ -106,7 +106,7 @@ namespace SQLJSON.Extensions
                     return string.Empty;
 
                 // Clean up any JSON escapes before returning
-                return JsonConvert.DeserializeObject(sbResult.ToString()).ToString();
+                return string.IsNullOrWhiteSpace(sbResult.ToString()) ? string.Empty : JsonConvert.DeserializeObject(sbResult.ToString()).ToString();
             }
 
             public async Task<string> ReadAllAsync()
@@ -123,7 +123,7 @@ namespace SQLJSON.Extensions
                     return string.Empty;
 
                 // Clean up any JSON escapes before returning
-                return JsonConvert.DeserializeObject(sbResult.ToString()).ToString();
+                return string.IsNullOrWhiteSpace(sbResult.ToString()) ? string.Empty : JsonConvert.DeserializeObject(sbResult.ToString()).ToString();
             }
 
             public override void Close()

--- a/SQLJSONReader/SQLJSONReader.csproj
+++ b/SQLJSONReader/SQLJSONReader.csproj
@@ -1,16 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyVersion>1.4.0.0</AssemblyVersion>
+    <FileVersion>1.4.0.0</FileVersion>
     <Authors>William Wegerson</Authors>
     <Company>Omega Technical Solutions</Company>
-    <Description>Provides a way to read JSON data from SQL Server when calling a stored procedure.</Description>
-    <Copyright>2019</Copyright>
+    <Description>Provides a way to read JSON data from SQL Server when calling a stored procedure. Simply extends SQLJSON reader to process data from SQL Server which is returned as JSON on the table/rows/columns and returns it to the user as a string.</Description>
+    <Copyright>2020</Copyright>
     <PackageLicenseUrl>https://licenses.nuget.org/MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/CheetahChrome/SQLJSONReader</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/CheetahChrome/SQLJSONReader/master/SQLJSONReader/images/Buddybleu.png</PackageIconUrl>
+    <Version>1.4.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Which occurred during a call to `JsonConvert` to de-serialize to remove any possible json escapes. Now it checks if the string is empty from the db and does not attempt to remove the spaces. 